### PR TITLE
replace moment js with date-fns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@
 
 # Ignore Byebug command history file.
 .byebug_history
+
+.vscode

--- a/app/javascript/src/scenes/bill/components/Content.js
+++ b/app/javascript/src/scenes/bill/components/Content.js
@@ -10,15 +10,13 @@ import { CopyLink } from 'shared/components'
 import { stylesheet, colors, mixins } from 'shared/styles'
 import type { Bill } from 'shared/types'
 
-const { floor } = Math
-
 let Content = class Content extends Component {
   props: {
     bill: Bill
   }
 
   // lifecycle
-  render() {
+  render () {
     const { bill } = this.props
 
     const now = new Date()

--- a/app/javascript/src/scenes/bill/components/Content.js
+++ b/app/javascript/src/scenes/bill/components/Content.js
@@ -1,9 +1,7 @@
 // @flow
 import React, { Component } from 'react'
 import { createFragmentContainer, graphql } from 'react-relay'
-import { default as parseDate } from 'date-fns/parse'
-import differenceInHours from 'date-fns/difference_in_hours'
-import { default as dateFormat } from 'date-fns/format'
+import { differenceInHours, formatDate, parseDate } from 'shared/date'
 import { Actions } from './Actions'
 import { Element } from './Element'
 import { CopyLink } from 'shared/components'
@@ -22,7 +20,7 @@ let Content = class Content extends Component {
     const now = new Date()
     const date = parseDate(bill.hearing.date)
     const hoursLeft = differenceInHours(date, now)
-    const formattedDate = dateFormat(date, 'M/D/YY h:mm A')
+    const formattedDate = formatDate(date, 'M/D/YY h:mm A')
 
     return <div>
       <div {...rules.header}>

--- a/app/javascript/src/scenes/bill/components/Content.js
+++ b/app/javascript/src/scenes/bill/components/Content.js
@@ -1,7 +1,9 @@
 // @flow
 import React, { Component } from 'react'
 import { createFragmentContainer, graphql } from 'react-relay'
-import moment from 'moment'
+import { default as parseDate } from 'date-fns/parse'
+import differenceInHours from 'date-fns/difference_in_hours'
+import { default as dateFormat } from 'date-fns/format'
 import { Actions } from './Actions'
 import { Element } from './Element'
 import { CopyLink } from 'shared/components'
@@ -16,12 +18,13 @@ let Content = class Content extends Component {
   }
 
   // lifecycle
-  render () {
+  render() {
     const { bill } = this.props
 
-    const now = moment()
-    const date = moment(bill.hearing.date)
-    const hoursLeft = floor(date.diff(now, 'hours', true))
+    const now = new Date()
+    const date = parseDate(bill.hearing.date)
+    const hoursLeft = differenceInHours(date, now)
+    const formattedDate = dateFormat(date, 'M/D/YY h:mm A')
 
     return <div>
       <div {...rules.header}>
@@ -39,8 +42,8 @@ let Content = class Content extends Component {
         </div>
         <div {...rules.column}>
           <Element label='Hearing Date'>
-            <span>{date.calendar()}</span>
-            {hoursLeft < 24 && <span {...rules.hoursLeft}>
+            <span>{formattedDate}</span>
+            {hoursLeft < 24 && hoursLeft > 0 && <span {...rules.hoursLeft}>
               {`(${hoursLeft} hours left)`}
             </span>}
           </Element>

--- a/app/javascript/src/scenes/bill/components/__tests__/Content.test.js
+++ b/app/javascript/src/scenes/bill/components/__tests__/Content.test.js
@@ -1,6 +1,7 @@
 /* eslint-env jest */
 import React from 'react'
-import moment from 'moment'
+import addHours from 'date-fns/add_hours'
+import { default as dateFormat } from 'date-fns/format'
 import { shallow } from 'enzyme'
 import { Content } from '../Content'
 
@@ -8,7 +9,7 @@ import { Content } from '../Content'
 let subject
 let bill
 
-function loadSubject () {
+function loadSubject() {
   subject = shallow(<Content bill={bill} />).dive()
 }
 
@@ -30,7 +31,7 @@ beforeEach(() => {
     title: 'Foo',
     summary: 'A bill, fantastic',
     hearing: {
-      date: moment().add(11.9, 'hours').utc()
+      date: addHours(new Date(), 11.9)
     },
     committee: {
       name: 'Many Pointed Bills'
@@ -59,7 +60,7 @@ describe('#render', () => {
     })
 
     it('shows the hearing date', () => {
-      expect(element.date()).toHaveText(moment(bill.hearing.date).calendar())
+      expect(element.date()).toHaveText(dateFormat(bill.hearing.date, 'D/M/YY'))
     })
 
     it('shows the hours left', () => {
@@ -77,7 +78,7 @@ describe('#render', () => {
 
   describe('when the date is over 23 hours away', () => {
     it('does not show the hours left', () => {
-      bill.hearing.date = moment().add(24.1, 'hours').utc()
+      bill.hearing.date = addHours(new Date(), 24.1)
       loadSubject()
       expect(element.hoursLeft().get(0)).toBeFalsy()
     })

--- a/app/javascript/src/scenes/bill/components/__tests__/Content.test.js
+++ b/app/javascript/src/scenes/bill/components/__tests__/Content.test.js
@@ -1,7 +1,6 @@
 /* eslint-env jest */
 import React from 'react'
-import addHours from 'date-fns/add_hours'
-import { default as dateFormat } from 'date-fns/format'
+import { addHours, formatDate } from 'shared/date'
 import { shallow } from 'enzyme'
 import { Content } from '../Content'
 
@@ -9,7 +8,7 @@ import { Content } from '../Content'
 let subject
 let bill
 
-function loadSubject () {
+function loadSubject() {
   subject = shallow(<Content bill={bill} />).dive()
 }
 
@@ -60,7 +59,7 @@ describe('#render', () => {
     })
 
     it('shows the hearing date', () => {
-      expect(element.date()).toHaveText(dateFormat(bill.hearing.date, 'D/M/YY'))
+      expect(element.date()).toHaveText(formatDate(bill.hearing.date, 'D/M/YY'))
     })
 
     it('shows the hours left', () => {

--- a/app/javascript/src/scenes/bill/components/__tests__/Content.test.js
+++ b/app/javascript/src/scenes/bill/components/__tests__/Content.test.js
@@ -9,7 +9,7 @@ import { Content } from '../Content'
 let subject
 let bill
 
-function loadSubject() {
+function loadSubject () {
   subject = shallow(<Content bill={bill} />).dive()
 }
 

--- a/app/javascript/src/scenes/search/components/BillCell.js
+++ b/app/javascript/src/scenes/search/components/BillCell.js
@@ -15,11 +15,11 @@ let BillCell = class BillCell extends Component {
   }
 
   // lifecycle
-  render() {
+  render () {
     const { bill, styles } = this.props
     const formattedDate = dateFormat(bill.hearing.date, 'DD/MM/YYYY')
 
-    return <div {...css(rules.container, styles) }>
+    return <div {...css(rules.container, styles)}>
       <div {...rules.info}>
         <div {...rules.header}>
           <div {...rules.document}>

--- a/app/javascript/src/scenes/search/components/BillCell.js
+++ b/app/javascript/src/scenes/search/components/BillCell.js
@@ -1,7 +1,7 @@
 // @flow
 import React, { Component } from 'react'
 import { createFragmentContainer, graphql } from 'react-relay'
-import moment from 'moment'
+import { default as dateFormat } from 'date-fns/format'
 import { css } from 'glamor'
 import type { Rule } from 'glamor'
 import type { Bill } from 'shared/types'
@@ -15,18 +15,18 @@ let BillCell = class BillCell extends Component {
   }
 
   // lifecycle
-  render () {
+  render() {
     const { bill, styles } = this.props
-    const date = moment(bill.hearing.date)
+    const formattedDate = dateFormat(bill.hearing.date, 'DD/MM/YYYY')
 
-    return <div {...css(rules.container, styles)}>
+    return <div {...css(rules.container, styles) }>
       <div {...rules.info}>
         <div {...rules.header}>
           <div {...rules.document}>
             <h3>{bill.title}</h3>
             <span>{bill.documentNumber}</span>
           </div>
-          <p>{date.calendar()}</p>
+          <p>{formattedDate}</p>
         </div>
         {bill.summary && <p {...rules.summary}>{bill.summary}</p>}
       </div>

--- a/app/javascript/src/scenes/search/components/BillCell.js
+++ b/app/javascript/src/scenes/search/components/BillCell.js
@@ -1,7 +1,7 @@
 // @flow
 import React, { Component } from 'react'
 import { createFragmentContainer, graphql } from 'react-relay'
-import { default as dateFormat } from 'date-fns/format'
+import { formatDate } from 'shared/date'
 import { css } from 'glamor'
 import type { Rule } from 'glamor'
 import type { Bill } from 'shared/types'
@@ -17,7 +17,7 @@ let BillCell = class BillCell extends Component {
   // lifecycle
   render () {
     const { bill, styles } = this.props
-    const formattedDate = dateFormat(bill.hearing.date, 'DD/MM/YYYY')
+    const formattedDate = formatDate(bill.hearing.date, 'DD/MM/YYYY')
 
     return <div {...css(rules.container, styles)}>
       <div {...rules.info}>

--- a/app/javascript/src/scenes/search/components/BillsList.js
+++ b/app/javascript/src/scenes/search/components/BillsList.js
@@ -4,7 +4,7 @@ import { createPaginationContainer, graphql } from 'react-relay'
 import type { RelayPaginationProp } from 'react-relay'
 import { withRouter } from 'react-router-dom'
 import type { ContextRouter } from 'react-router-dom'
-import type moment from 'moment'
+import { default as dateFormat } from 'date-fns/format'
 import { BillCell } from './BillCell'
 import { BillAnimation, billRule } from './BillAnimation'
 import { LoadMoreButton } from './LoadMoreButton'
@@ -14,8 +14,8 @@ import { session } from 'shared/storage'
 import { stylesheet, mixins } from 'shared/styles'
 import type { Viewer } from 'shared/types'
 
-function format (date: moment): string {
-  return date.format('MMM Do')
+function format(date: Date): string {
+  return dateFormat(date, 'MMM Do')
 }
 
 let BillsList = class BillsList extends Component {
@@ -44,26 +44,26 @@ let BillsList = class BillsList extends Component {
   }
 
   // lifecycle
-  componentWillMount () {
+  componentWillMount() {
     if (this.props.history.action === 'POP') {
       this.setState({ disableAnimations: true })
     }
   }
 
-  componentDidMount () {
+  componentDidMount() {
     if (this.props.history.action === 'POP') {
       this.setState({ disableAnimations: false })
     }
   }
 
-  componentWillUnmount () {
+  componentWillUnmount() {
     const { viewer } = this.props
     if (viewer) {
       session.set('last-search-count', `${viewer.bills.edges.length}`)
     }
   }
 
-  render () {
+  render() {
     const { disableAnimations } = this.state
     const { relay, viewer, animated } = this.props
     const { bills } = viewer
@@ -87,7 +87,7 @@ let BillsList = class BillsList extends Component {
     </div>
   }
 
-  renderBills (bills): Array<React$Element<*>> {
+  renderBills(bills): Array<React$Element<*>> {
     return bills.map((bill, i) => {
       return <BillCell key={bill.id} styles={billRule} bill={bill} />
     })
@@ -116,7 +116,7 @@ BillsList = createPaginationContainer(withRouter(BillsList),
     }
   `,
   withLoadMoreArgs({
-    getConnectionFromProps (props) {
+    getConnectionFromProps(props) {
       return props.viewer && props.viewer.bills
     },
     query: graphql`

--- a/app/javascript/src/scenes/search/components/BillsList.js
+++ b/app/javascript/src/scenes/search/components/BillsList.js
@@ -4,7 +4,7 @@ import { createPaginationContainer, graphql } from 'react-relay'
 import type { RelayPaginationProp } from 'react-relay'
 import { withRouter } from 'react-router-dom'
 import type { ContextRouter } from 'react-router-dom'
-import { default as dateFormat } from 'date-fns/format'
+import { formatDate } from 'shared/date'
 import { BillCell } from './BillCell'
 import { BillAnimation, billRule } from './BillAnimation'
 import { LoadMoreButton } from './LoadMoreButton'
@@ -15,7 +15,7 @@ import { stylesheet, mixins } from 'shared/styles'
 import type { Viewer } from 'shared/types'
 
 function format (date: Date): string {
-  return dateFormat(date, 'MMM Do')
+  return formatDate(date, 'MMM Do')
 }
 
 let BillsList = class BillsList extends Component {

--- a/app/javascript/src/scenes/search/components/BillsList.js
+++ b/app/javascript/src/scenes/search/components/BillsList.js
@@ -14,7 +14,7 @@ import { session } from 'shared/storage'
 import { stylesheet, mixins } from 'shared/styles'
 import type { Viewer } from 'shared/types'
 
-function format(date: Date): string {
+function format (date: Date): string {
   return dateFormat(date, 'MMM Do')
 }
 
@@ -44,26 +44,26 @@ let BillsList = class BillsList extends Component {
   }
 
   // lifecycle
-  componentWillMount() {
+  componentWillMount () {
     if (this.props.history.action === 'POP') {
       this.setState({ disableAnimations: true })
     }
   }
 
-  componentDidMount() {
+  componentDidMount () {
     if (this.props.history.action === 'POP') {
       this.setState({ disableAnimations: false })
     }
   }
 
-  componentWillUnmount() {
+  componentWillUnmount () {
     const { viewer } = this.props
     if (viewer) {
       session.set('last-search-count', `${viewer.bills.edges.length}`)
     }
   }
 
-  render() {
+  render () {
     const { disableAnimations } = this.state
     const { relay, viewer, animated } = this.props
     const { bills } = viewer
@@ -87,7 +87,7 @@ let BillsList = class BillsList extends Component {
     </div>
   }
 
-  renderBills(bills): Array<React$Element<*>> {
+  renderBills (bills): Array<React$Element<*>> {
     return bills.map((bill, i) => {
       return <BillCell key={bill.id} styles={billRule} bill={bill} />
     })
@@ -116,7 +116,7 @@ BillsList = createPaginationContainer(withRouter(BillsList),
     }
   `,
   withLoadMoreArgs({
-    getConnectionFromProps(props) {
+    getConnectionFromProps (props) {
       return props.viewer && props.viewer.bills
     },
     query: graphql`

--- a/app/javascript/src/scenes/search/components/__tests__/BillsList.test.js
+++ b/app/javascript/src/scenes/search/components/__tests__/BillsList.test.js
@@ -5,16 +5,16 @@ import { BillsList } from '../BillsList'
 import { routerProps } from 'mocks/routerProps'
 import { session } from 'shared/storage'
 import { relayPaginationProp } from 'mocks/relayProps'
-
 const { anything } = expect
 
 // mocks
 jest.mock('../../searchRoute', () => {
-  const moment = require('moment')
+  const addMonths = require('date-fns/add_months')
+  const addDays = require('date-fns/add_days')
   const constants = {
     count: 999,
-    startDate: moment().month(4).date(1),
-    endDate: moment().month(4).date(7)
+    startDate: addMonths(new Date(2016, 12, 1), 4),
+    endDate: addDays(addMonths(new Date(2016, 12, 1), 4), 6),
   }
 
   return { constants }
@@ -25,11 +25,11 @@ let subject
 let viewer
 let animated
 
-function loadSubject () {
+function loadSubject() {
   subject = shallow(<BillsList viewer={viewer} animated={animated} />).dive().dive()
 }
 
-function edges (nodes) {
+function edges(nodes) {
   return nodes.map((node) => ({ node }))
 }
 

--- a/app/javascript/src/scenes/search/components/__tests__/BillsList.test.js
+++ b/app/javascript/src/scenes/search/components/__tests__/BillsList.test.js
@@ -14,7 +14,7 @@ jest.mock('../../searchRoute', () => {
   const constants = {
     count: 999,
     startDate: addMonths(new Date(2016, 12, 1), 4),
-    endDate: addDays(addMonths(new Date(2016, 12, 1), 4), 6),
+    endDate: addDays(addMonths(new Date(2016, 12, 1), 4), 6)
   }
 
   return { constants }
@@ -25,11 +25,11 @@ let subject
 let viewer
 let animated
 
-function loadSubject() {
+function loadSubject () {
   subject = shallow(<BillsList viewer={viewer} animated={animated} />).dive().dive()
 }
 
-function edges(nodes) {
+function edges (nodes) {
   return nodes.map((node) => ({ node }))
 }
 

--- a/app/javascript/src/scenes/search/searchRoute.js
+++ b/app/javascript/src/scenes/search/searchRoute.js
@@ -1,9 +1,7 @@
 // @flow
 import React from 'react'
 import { graphql } from 'react-relay'
-import addDays from 'date-fns/add_days'
-import endOfDay from 'date-fns/end_of_day'
-import startOfDay from 'date-fns/start_of_day'
+import { addDays, endOfDay, startOfDay } from 'shared/date'
 import { SearchScene } from './SearchScene'
 import { createPaginationCacheResolver } from 'shared/relay'
 import { session } from 'shared/storage'

--- a/app/javascript/src/scenes/search/searchRoute.js
+++ b/app/javascript/src/scenes/search/searchRoute.js
@@ -1,7 +1,9 @@
 // @flow
 import React from 'react'
 import { graphql } from 'react-relay'
-import moment from 'moment'
+import addDays from 'date-fns/add_days'
+import endOfDay from 'date-fns/end_of_day'
+import startOfDay from 'date-fns/start_of_day'
 import { SearchScene } from './SearchScene'
 import { createPaginationCacheResolver } from 'shared/relay'
 import { session } from 'shared/storage'
@@ -10,8 +12,8 @@ import type { RelayRouteConfig } from 'shared/types'
 export const constants = {
   query: '',
   count: 20,
-  startDate: moment().startOf('day'),
-  endDate: moment().add(6, 'days').endOf('day')
+  startDate: startOfDay(new Date()),
+  endDate: endOfDay(addDays(new Date(), 6))
 }
 
 export const searchRoute: RelayRouteConfig = {
@@ -25,7 +27,7 @@ export const searchRoute: RelayRouteConfig = {
       }
     }
   `,
-  getInitialVariables (props) {
+  getInitialVariables(props) {
     // use the last search count on pop so that we can restore to the correct
     // scroll position
     let count = null
@@ -46,7 +48,7 @@ export const searchRoute: RelayRouteConfig = {
     queryId: 'BillsConnection',
     queryPathToConnection: ['viewer', 'bills']
   }),
-  render (props) {
+  render(props) {
     if (props) {
       return <SearchScene {...props} />
     } else {

--- a/app/javascript/src/scenes/search/searchRoute.js
+++ b/app/javascript/src/scenes/search/searchRoute.js
@@ -27,7 +27,7 @@ export const searchRoute: RelayRouteConfig = {
       }
     }
   `,
-  getInitialVariables(props) {
+  getInitialVariables (props) {
     // use the last search count on pop so that we can restore to the correct
     // scroll position
     let count = null
@@ -48,7 +48,7 @@ export const searchRoute: RelayRouteConfig = {
     queryId: 'BillsConnection',
     queryPathToConnection: ['viewer', 'bills']
   }),
-  render(props) {
+  render (props) {
     if (props) {
       return <SearchScene {...props} />
     } else {

--- a/app/javascript/src/shared/date.js
+++ b/app/javascript/src/shared/date.js
@@ -1,0 +1,8 @@
+export { default as addDays } from 'date-fns/add_days'
+export { default as addHours } from 'date-fns/add_hours'
+export { default as addMonths } from 'date-fns/add_months'
+export { default as differenceInHours } from 'date-fns/difference_in_hours'
+export { default as endOfDay } from 'date-fns/end_of_day'
+export { default as formatDate } from 'date-fns/format'
+export { default as parseDate } from 'date-fns/parse'
+export { default as startOfDay } from 'date-fns/start_of_day'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,4 +9,7 @@ Rails.application.routes.draw do
     mount GraphiQL::Rails::Engine, at: '/graphiql', graphql_path: '/graphql'
     mount LetterOpenerWeb::Engine, at: '/letter_opener'
   end
+
+  # All other html requests should go to the js app
+  get '/(*any)', to: 'client#index', constraints: { format: 'html' }
 end

--- a/config/webpack/shared.js
+++ b/config/webpack/shared.js
@@ -3,7 +3,6 @@ const { environment } = require('@rails/webpacker')
 const merge = require('webpack-merge')
 const path = require('path')
 const RelayCompilerPlugin = require('relay-compiler-webpack-plugin')
-const webpack = require('webpack')
 
 const client = './app/javascript'
 const config = merge(environment.toWebpackConfig(), {
@@ -16,8 +15,7 @@ const config = merge(environment.toWebpackConfig(), {
     new RelayCompilerPlugin({
       src: path.resolve(client, './src'),
       schema: path.resolve('./schema.json')
-    }),
-    new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/)
+    })
   ]
 })
 

--- a/package.json
+++ b/package.json
@@ -79,26 +79,12 @@
   },
   "babel": {
     "presets": [
-      [
-        "env",
-        {
-          "targets": {
-            "browsers": [
-              "last 2 versions"
-            ]
-          }
-        }
-      ],
+      [ "env", { "targets": { "browsers": [ "last 2 versions" ] } } ],
       "react"
     ],
     "plugins": [
       "lodash",
-      [
-        "relay",
-        {
-          "schema": "schema.json"
-        }
-      ],
+      [ "relay", { "schema": "schema.json" } ],
       "transform-flow-strip-types",
       "transform-class-properties",
       "transform-object-rest-spread"

--- a/package.json
+++ b/package.json
@@ -24,11 +24,11 @@
   "dependencies": {
     "@rails/webpacker": "^3.0.2",
     "color": "^2.0.0",
+    "date-fns": "^1.29.0",
     "eventemitter3": "^2.0.3",
     "glamor": "2.20.25",
     "js-base64": "^2.1.9",
     "lodash": "^4.17.2",
-    "moment": "^2.18.1",
     "react": "^15.6.1",
     "react-addons-css-transition-group": "^15.6.0",
     "react-copy-to-clipboard": "^5.0.0",
@@ -79,12 +79,26 @@
   },
   "babel": {
     "presets": [
-      [ "env", { "targets": { "browsers": [ "last 2 versions" ] } } ],
+      [
+        "env",
+        {
+          "targets": {
+            "browsers": [
+              "last 2 versions"
+            ]
+          }
+        }
+      ],
       "react"
     ],
     "plugins": [
       "lodash",
-      [ "relay", { "schema": "schema.json" } ],
+      [
+        "relay",
+        {
+          "schema": "schema.json"
+        }
+      ],
       "transform-flow-strip-types",
       "transform-class-properties",
       "transform-object-rest-spread"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2154,6 +2154,10 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
+date-fns@^1.29.0:
+  version "1.29.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.29.0.tgz#12e609cdcb935127311d04d33334e2960a2a54e6"
+
 date-now@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/date-now/-/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b"
@@ -5631,10 +5635,6 @@ mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkd
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
     minimist "0.0.8"
-
-moment@^2.18.1:
-  version "2.19.1"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.19.1.tgz#56da1a2d1cbf01d38b7e1afc31c10bcfa1929167"
 
 mozjpeg@^4.0.0:
   version "4.1.1"


### PR DESCRIPTION
There is no direct equivalent for moment's `.calendar()`. For now, on the bill page, I am showing the date and time with no fancy 'Today', 'Yesterday', etc...